### PR TITLE
Simplify UrlEncoding

### DIFF
--- a/src/google-diff-match-patch/Patch.cs
+++ b/src/google-diff-match-patch/Patch.cs
@@ -74,12 +74,12 @@ namespace DiffMatchPatch
         public override string ToString()
         {
             var text = new StringBuilder();
-            text.AppendNewline($"@@ {Coordinates} @@");
+            text.AppendWithNewline($"@@ {Coordinates} @@");
 
             // Escape the body of the patch with %xx notation.
             foreach (var aDiff in Diffs)
             {
-                text.AppendNewline($"{(char)aDiff.Operation}{aDiff.Text.UrlEncoded()}");
+                text.AppendWithNewline($"{(char)aDiff.Operation}{aDiff.Text.UrlEncoded()}");
             }
 
             return text.ToString();

--- a/src/google-diff-match-patch/Patch.cs
+++ b/src/google-diff-match-patch/Patch.cs
@@ -74,15 +74,15 @@ namespace DiffMatchPatch
         public override string ToString()
         {
             var text = new StringBuilder();
-            text.AppendLine($"@@ {Coordinates} @@");
+            text.AppendNewline($"@@ {Coordinates} @@");
 
             // Escape the body of the patch with %xx notation.
             foreach (var aDiff in Diffs)
             {
-                text.AppendLine($"{(char)aDiff.Operation}{aDiff.Text.UrlEncoded()}");
+                text.AppendNewline($"{(char)aDiff.Operation}{aDiff.Text.UrlEncoded()}");
             }
 
-            return text.ToString().Replace("\r\n", "\n");
+            return text.ToString();
         }
 
         internal Patch Copy()

--- a/src/google-diff-match-patch/StringBuilderExtensions.cs
+++ b/src/google-diff-match-patch/StringBuilderExtensions.cs
@@ -19,7 +19,7 @@ namespace DiffMatchPatch
 
             return stringOutput;
         }
-        public static StringBuilder AppendNewline(this StringBuilder sb, string append) 
+        public static StringBuilder AppendWithNewline(this StringBuilder sb, string append) 
         { 
             return sb.Append(append).Append('\n');
         }

--- a/src/google-diff-match-patch/StringBuilderExtensions.cs
+++ b/src/google-diff-match-patch/StringBuilderExtensions.cs
@@ -19,5 +19,9 @@ namespace DiffMatchPatch
 
             return stringOutput;
         }
+        public static StringBuilder AppendNewline(this StringBuilder sb, string append) 
+        { 
+            return sb.Append(append).Append('\n');
+        }
     }
 }

--- a/src/google-diff-match-patch/TextUtil.cs
+++ b/src/google-diff-match-patch/TextUtil.cs
@@ -236,7 +236,10 @@ namespace DiffMatchPatch
                 else
                 {
                     var bytes = Encoding.UTF8.GetBytes(new[] { c });
-                    sb.Append(string.Join("", bytes.Select(b => $"%{b:x2}")));
+                    foreach (byte b in bytes)
+                    {
+                        sb.Append($"%{b:x2}");
+                    }
                 }
             }
             return sb.ToString();


### PR DESCRIPTION
2 simple changes:
- rather than use StringBuilder.Appendline and then create a string and subsequently replace all "\r\n" with "\n" just create an extension method which only adds the"\n".
- Rather than add a number of non-standard URIencoded characters (a problem with the microsoft implementation), then decode them all back, then make them all lower case, just encode the characters which need it. As per the comment included in the code, this will be cleaner still once upgraded to .NET 7 allowing char.IsAlphaOrAsciiLetter(c) method.